### PR TITLE
`perf_to_profile` ELF from `google/perf_data_converter` is dynamically linked against libelf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN bazel build src:perf_to_profile
 RUN cp bazel-bin/src/perf_to_profile /usr/bin/.
 
 FROM golang:latest
+# perf_to_profile is dynamically linked against libelf
+COPY --from=perf_data_converter /usr/lib/x86_64-linux-gnu/libelf.so /usr/lib/x86_64-linux-gnu/libelf.so
 COPY --from=perf_data_converter /usr/bin/perf_to_profile /usr/bin/perf_to_profile
 COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 


### PR DESCRIPTION
Hello 👋 

The `perf_to_profile` ELF from `google/perf_data_converter` is dynamically linked against `libelf`.

```
$ ./envoy-perf-pprof.sh v1.21.1 envoy.perf
[+] Building 0.9s (19/19) FINISHED
 => [internal] load build definition from Dockerfile                                                                                0.0s
 => => transferring dockerfile: 793B                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                   0.0s
 => => transferring context: 2B                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/golang:latest                                                                    0.6s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                     0.6s
 => [internal] load metadata for docker.io/envoyproxy/envoy-debug:v1.21.1                                                           0.8s
 => [perf_data_converter 1/7] FROM docker.io/library/ubuntu:18.04@sha256:42cd9143b6060261187a72716906187294b8b66653b50d70bc7a90cca  0.0s
 => [envoy 1/1] FROM docker.io/envoyproxy/envoy-debug:v1.21.1@sha256:f85f3a47495d58866f17430b2bbfd3efddd97049ede4f2c435f2af0b758e2  0.0s
 => [stage-2 1/5] FROM docker.io/library/golang:latest@sha256:c7c94588b6445f5254fbc34df941afa10de04706deb330e62831740c9f0f2030      0.0s
 => CACHED [perf_data_converter 2/7] RUN apt update && apt install -y npm g++ git libelf-dev libcap-dev                             0.0s
 => CACHED [perf_data_converter 3/7] RUN npm install -g @bazel/bazelisk                                                             0.0s
 => CACHED [perf_data_converter 4/7] RUN git clone https://github.com/google/perf_data_converter.git /usr/src/perf_data_converter   0.0s
 => CACHED [perf_data_converter 5/7] WORKDIR /usr/src/perf_data_converter                                                           0.0s
 => CACHED [perf_data_converter 6/7] RUN bazel build src:perf_to_profile                                                            0.0s
 => CACHED [perf_data_converter 7/7] RUN cp bazel-bin/src/perf_to_profile /usr/bin/.                                                0.0s
 => CACHED [stage-2 2/5] COPY --from=perf_data_converter /usr/bin/perf_to_profile /usr/bin/perf_to_profile                          0.0s
 => CACHED [stage-2 3/5] COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy                                                0.0s
 => CACHED [stage-2 4/5] RUN apt update && apt install -y graphviz                                                                  0.0s
 => CACHED [stage-2 5/5] RUN go get -u github.com/google/pprof                                                                      0.0s
 => exporting to image                                                                                                              0.0s
 => => exporting layers                                                                                                             0.0s
 => => writing image sha256:33d6b2c73a011f212b7398a3f9a82159c8530a0a0e3da95110c8b548ce5496ab                                        0.0s
 => => naming to docker.io/library/envoy-perf-pprof                                                                                 0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Converting /root/envoy.perf to a profile.proto... (May take a few minutes)
perf_to_profile: error while loading shared libraries: libelf.so.1: cannot open shared object file: No such file or directory
/root/envoy.perf: failed to convert perf.data file. Try github.com/google/perf_data_converter: exit status 127
pprof: failed to fetch any source profiles
```


```
# ldd `which perf_to_profile`
        linux-vdso.so.1 (0x00007ffd42938000)
        libelf.so.1 => not found
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fe6d7f87000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fe6d7e43000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fe6d7c76000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fe6d7c5c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fe6d7a97000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fe6d840b000)
```

This copies the shared object from the build container where `libelf-dev` package was installed.


Thank you and have a nice day.